### PR TITLE
Fixes for [SSL: DH_KEY_TOO_SMALL] and "can only concatenate str not int" crashes

### DIFF
--- a/greenwavereality/greenwavereality.py
+++ b/greenwavereality/greenwavereality.py
@@ -2,6 +2,7 @@ import requests
 import xmltodict
 import urllib3
 
+requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += 'HIGH:!DH:!aNULL'
 
 def grab_xml(host, token=None):
     """Grab XML data from Gateway, returned as a dict."""
@@ -28,7 +29,7 @@ def set_brightness(host, did, value, token=None):
         scheme = "http"
         token = "1234567890"
     url = (
-            scheme + '://' + host + '/gwr/gop.php?cmd=DeviceSendCommand&data=<gip><version>1</version><token>' + token + '</token><did>' + did + '</did><value>' + str(
+            scheme + '://' + host + '/gwr/gop.php?cmd=DeviceSendCommand&data=<gip><version>1</version><token>' + token + '</token><did>' + str(did) + '</did><value>' + str(
         value) + '</value><type>level</type></gip>&fmt=xml')
     response = requests.get(url, verify=False)
     if response.status_code == '200':
@@ -55,7 +56,7 @@ def turn_on(host, did, token=None):
         scheme = "http"
         token = "1234567890"
     url = (
-            scheme + '://' + host + '/gwr/gop.php?cmd=DeviceSendCommand&data=<gip><version>1</version><token>' + token + '</token><did>' + did + '</did><value>1</value></gip>&fmt=xml')
+            scheme + '://' + host + '/gwr/gop.php?cmd=DeviceSendCommand&data=<gip><version>1</version><token>' + token + '</token><did>' + str(did) + '</did><value>1</value></gip>&fmt=xml')
     response = requests.get(url, verify=False)
     if response.status_code == '200':
         return True
@@ -72,7 +73,7 @@ def turn_off(host, did, token=None):
         scheme = "http"
         token = "1234567890"
     url = (
-            scheme + '://' + host + '/gwr/gop.php?cmd=DeviceSendCommand&data=<gip><version>1</version><token>' + token + '</token><did>' + did + '</did><value>0</value></gip>&fmt=xml')
+            scheme + '://' + host + '/gwr/gop.php?cmd=DeviceSendCommand&data=<gip><version>1</version><token>' + token + '</token><did>' + str(did) + '</did><value>0</value></gip>&fmt=xml')
     response = requests.get(url, verify=False)
     if response.status_code == '200':
         return True


### PR DESCRIPTION
The Greenwave Reality gateway's HTTP server is using old no longer supported DH ciphers. Current python/openssl versions will crash with an [SSL: DH_KEY_TOO_SMALL] error.

Also, when the value of "did" is an integer, you'll get a **can only concatenate str (not "int") to str** error.

This PR fixes both issues.